### PR TITLE
feat: make integration simpler

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,11 +26,12 @@ Default usage defines a self-contained Web Component that renders inside a Shado
   })
   </script>
 
-<!-- Place the element anywhere in your page (embedded) -->
+<!-- Place the element anywhere in your page (embedded). Provide a host height. -->
 <tinfoil-verification-center
   mode="embedded"
   is-dark-mode="true"
   show-verification-flow="true"
+  style="height: min(80vh, 680px); width: min(720px, 100%); overflow: hidden; border-radius: 8px;"
   config-repo="tinfoilsh/confidential-inference-proxy"
   base-url="https://inference.tinfoil.sh"
 ></tinfoil-verification-center>
@@ -117,8 +118,10 @@ Install as usual, then import the package (default WC) once and place the elemen
 </script>
 
 <tinfoil-verification-center
+  mode="embedded"
   is-dark-mode="true"
   show-verification-flow="true"
+  style="height: min(80vh, 680px); width: min(720px, 100%); overflow: hidden; border-radius: 8px;"
   config-repo="tinfoilsh/confidential-inference-proxy"
   base-url="https://inference.tinfoil.sh"
 ></tinfoil-verification-center>

--- a/examples/dev/src/App.tsx
+++ b/examples/dev/src/App.tsx
@@ -32,46 +32,21 @@ export function App() {
     [isDarkMode],
   )
 
-  // Web Component host container
-  const wcHostRef = useRef<HTMLDivElement | null>(null)
-  const wcElRef = useRef<HTMLElement | null>(null)
-
-  // Create/remove the element as the demo opens/closes
+  // Ref the custom element to set the document and listen for close
+  const wcRef = useRef<any>(null)
   useEffect(() => {
-    const host = wcHostRef.current
-    if (!host) return
-
-    if (isVerifierOpen) {
-      // Create if missing
-      if (!wcElRef.current) {
-        wcElRef.current = document.createElement('tinfoil-verification-center') as any
-      }
-      // Ensure appended to current host
-      if (wcElRef.current.parentElement !== host) {
-        host.appendChild(wcElRef.current)
-      }
-      // Wire close event from WC header
-      const handleClose = () => setIsVerifierOpen(false)
-      wcElRef.current.addEventListener('close', handleClose)
-      return () => {
-        wcElRef.current?.removeEventListener('close', handleClose)
-      }
-    }
-
-    if (!isVerifierOpen && wcElRef.current) {
-      wcElRef.current.remove()
-      wcElRef.current = null
-    }
-  }, [isVerifierOpen, displayMode])
-
-  // Keep WC props in sync with controls
-  useEffect(() => {
-    const el = wcElRef.current as any
+    const el = wcRef.current as any
     if (!el) return
-    el.setAttribute('is-dark-mode', String(isDarkMode))
-    el.setAttribute('show-verification-flow', String(showFlow))
+    const handleClose = () => setIsVerifierOpen(false)
+    el.addEventListener('close', handleClose)
+    return () => el.removeEventListener('close', handleClose)
+  }, [])
+
+  useEffect(() => {
+    const el = wcRef.current as any
+    if (!el) return
     el.verificationDocument = verificationDocument
-  }, [isDarkMode, showFlow, verificationDocument, isVerifierOpen])
+  }, [verificationDocument])
 
   return (
     <div className={appClassName}>
@@ -153,62 +128,14 @@ export function App() {
 
       <main className="app__main">Webpage</main>
 
-      {displayMode === 'sidebar' && isVerifierOpen ? (
-        <div
-          className="wc-sidebar"
-          style={{
-            position: 'fixed',
-            top: 0,
-            right: 0,
-            height: '100vh',
-            width: 420,
-            maxWidth: '100%',
-            borderLeft: '1px solid #e5e7eb',
-            background: isDarkMode ? '#0b0f16' : '#ffffff',
-            boxShadow: '0 0 0 1px rgba(0,0,0,0.03), 0 10px 15px rgba(0,0,0,0.08)',
-            overflow: 'hidden',
-            zIndex: 40,
-          }}
-        >
-          <div
-            ref={wcHostRef}
-            style={{ height: '100%', width: '100%' }}
-          />
-        </div>
-      ) : null}
-
-      {displayMode === 'modal' && isVerifierOpen ? (
-        <div
-          className="wc-overlay"
-          onClick={() => setIsVerifierOpen(false)}
-          style={{
-            position: 'fixed',
-            inset: 0,
-            background: 'rgba(17,24,39,0.5)',
-            display: 'flex',
-            alignItems: 'center',
-            justifyContent: 'center',
-            zIndex: 50,
-          }}
-        >
-          <div
-            className="wc-modal"
-            onClick={(e) => e.stopPropagation()}
-            style={{
-              width: 'min(720px, 100%)',
-              height: 'min(80vh, 680px)',
-              borderRadius: 8,
-              overflow: 'hidden',
-              border: '1px solid #e5e7eb',
-              background: isDarkMode ? '#0b0f16' : '#ffffff',
-              boxShadow:
-                '0 0 0 1px rgba(0,0,0,0.03), 0 25px 50px rgba(0,0,0,0.15)',
-            }}
-          >
-            <div ref={wcHostRef} style={{ height: '100%', width: '100%' }} />
-          </div>
-        </div>
-      ) : null}
+      {/* Single custom element handles sidebar or modal */}
+      <tinfoil-verification-center
+        ref={wcRef}
+        mode={displayMode}
+        open={isVerifierOpen as unknown as any}
+        is-dark-mode={isDarkMode ? 'true' : 'false'}
+        show-verification-flow={showFlow ? 'true' : 'false'}
+      />
     </div>
   )
 }

--- a/examples/dev/src/App.tsx
+++ b/examples/dev/src/App.tsx
@@ -3,7 +3,7 @@ import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import '@tinfoilsh/verification-center-ui'
 import { mockFailureDocument, mockSuccessDocument } from './fake-document'
 
-type DisplayMode = 'sidebar' | 'modal'
+type DisplayMode = 'sidebar' | 'modal' | 'embedded'
 type MockOutcome = 'success' | 'failure'
 
 export function App() {
@@ -121,6 +121,16 @@ export function App() {
               />
               Modal
             </label>
+            <label>
+              <input
+                type="radio"
+                name="display-mode"
+                value="embedded"
+                checked={displayMode === 'embedded'}
+                onChange={() => handleModeChange('embedded')}
+              />
+              Embedded
+            </label>
             
           </div>
         </section>
@@ -129,13 +139,25 @@ export function App() {
       <main className="app__main">Webpage</main>
 
       {/* Single custom element handles sidebar or modal */}
-      <tinfoil-verification-center
-        ref={wcRef}
-        mode={displayMode}
-        open={isVerifierOpen as unknown as any}
-        is-dark-mode={isDarkMode ? 'true' : 'false'}
-        show-verification-flow={showFlow ? 'true' : 'false'}
-      />
+      {isVerifierOpen && (
+        <tinfoil-verification-center
+          ref={wcRef}
+          mode={displayMode}
+          open={displayMode !== 'embedded' ? (isVerifierOpen as unknown as any) : undefined}
+          is-dark-mode={isDarkMode ? 'true' : 'false'}
+          show-verification-flow={showFlow ? 'true' : 'false'}
+          style={
+            displayMode === 'embedded'
+              ? ({
+                  width: 'min(720px, 100%)',
+                  height: 'min(80vh, 680px)',
+                  borderRadius: 8,
+                  overflow: 'hidden',
+                } as React.CSSProperties)
+              : undefined
+          }
+        />
+      )}
     </div>
   )
 }

--- a/examples/dev/src/global.d.ts
+++ b/examples/dev/src/global.d.ts
@@ -1,1 +1,23 @@
 declare module '*.css'
+
+// Allow using the custom element in TSX without type errors
+import type React from 'react'
+
+declare global {
+  namespace JSX {
+    interface IntrinsicElements {
+      'tinfoil-verification-center': React.DetailedHTMLProps<
+        React.HTMLAttributes<HTMLElement>,
+        HTMLElement
+      > & {
+        'is-dark-mode'?: boolean | string
+        'show-verification-flow'?: boolean | string
+        'config-repo'?: string
+        'base-url'?: string
+        mode?: 'embedded' | 'sidebar' | 'modal'
+        open?: boolean | string
+        'sidebar-width'?: number | string
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tinfoilsh/verification-center-ui",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "description": "Self-contained Web Component for the Tinfoil verification center UI",
   "main": "dist/wc/tinfoil-wc.es.js",
   "module": "dist/wc/tinfoil-wc.es.js",


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Adds built-in sidebar and modal modes to the web component, controlled by mode and open, with a close event that hides the UI. Updates docs and the example to use a single element, adds TSX typings, and improves prop handling to avoid unnecessary re-renders.

- **New Features**
  - mode="embedded" | "sidebar" | "modal" with open to show/hide; sidebar-width to size the sidebar.
  - Close button now removes open and dispatches a close event for app state sync.
  - Modal and sidebar wrappers render inside the Shadow DOM; no extra host markup needed.
  - Smarter prop parsing and caching to skip unnecessary renders.
  - TSX typings for the custom element in React.

- **Migration**
  - Replace custom wrappers with a single <tinfoil-verification-center> and set mode + open.
  - Listen for the close event to update your app state.
  - In React, pass hyphenated boolean attributes as strings ('true' | 'false').

<!-- End of auto-generated description by cubic. -->

